### PR TITLE
chore(ci): Use --legacy-peer-deps flag for npm ci and npm i commands

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 12.x
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Rebuild the dist/ directory
         run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          npm install
+          npm install --legacy-peer-deps
       - run: |
           npm run all
   test: # make sure the action works on a clean machine without building


### PR DESCRIPTION
Signed-off-by: Oğuzhan Durgun <oguzhandurgun95@gmail.com>

