### PR TITLE
chore: Update actions/*@v2 to v3

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -3,7 +3,7 @@
 # `index.js` is the code that will run.
 # For our project, we generate this file through a build process from other source files.
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
-name: Check dist/
+name: Check dist
 
 on:
   push:
@@ -21,11 +21,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set Node.js 16
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           node-version: 16.x
 
       - name: Install dependencies
@@ -44,7 +45,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           npm install --legacy-peer-deps
       - run: |
@@ -18,9 +18,8 @@ jobs:
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cerbos/cerbos-setup-action@v1
         with:
-          github_token: ${{ github.token }}
           version: 'latest'
       - uses: ./


### PR DESCRIPTION
- Version 2 of GitHub actions (actions/*@v2) runs on Node 12, which is why we are seeing some warnings.